### PR TITLE
[CI test] Verify cleanup-ci-w22712082 workflows trigger correctly

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
   # pull_request_target is required for fork PRs to receive secrets.
   # Mitigated by per-job Member Check (see "Check Write Permission" / "Validate Write Permission").
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [dev, master]
+    branches: [dev, master, cleanup-ci-w22712082]
 
 permissions:
   contents: read

--- a/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
@@ -1,3 +1,4 @@
+// CI test trigger for W-22712082; revert before merge.
 /*
  SFSDKLogger.m
  SalesforceFileLogger


### PR DESCRIPTION
## Purpose

Test PR to exercise the new `cleanup-ci-w22712082` workflow files before opening the upstream PR (W-22712082).

This PR is internal to the fork — it triggers `pull_request_target` on `cleanup-ci-w22712082` so the new workflows execute against a real source change.

## What's in the diff

- `.github/workflows/pr.yaml`: temporarily extend `branches:` filter to include `cleanup-ci-w22712082` so this test PR triggers CI. Reverted before upstream PR.
- `libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m`: trivial comment to drive the build pipeline. Reverted before upstream PR.

## Acceptance

CI must succeed on this PR (or fail only for environmental/secret reasons unrelated to the workflow changes). Once green, the upstream PR for the underlying `cleanup-ci-w22712082` branch can be opened against forcedotcom:dev.

DO NOT MERGE — for CI verification only.